### PR TITLE
Only replace vanilla villagers

### DIFF
--- a/src/main/java/mca/core/forge/EventHooksForge.java
+++ b/src/main/java/mca/core/forge/EventHooksForge.java
@@ -40,7 +40,7 @@ public class EventHooksForge
 				doAddMobTasks((EntityMob) event.entity);
 			}
 
-			if (event.entity instanceof EntityVillager && !(event.entity instanceof EntityHuman) && MCA.getConfig().overwriteOriginalVillagers)
+			if (event.entity.getClass() == EntityVillager.class && MCA.getConfig().overwriteOriginalVillagers)
 			{
 				doOverwriteVillager(event, (EntityVillager) event.entity);
 			}


### PR DESCRIPTION
Don't replace entities added by other mods that extend EntityVillager (I noticed this with the NPCs from Nevermine)