### PR TITLE
Fix a few server crashes.

### DIFF
--- a/src/main/java/mca/items/ItemBaby.java
+++ b/src/main/java/mca/items/ItemBaby.java
@@ -161,7 +161,7 @@ public class ItemBaby extends Item
 	public boolean onEntityItemUpdate(EntityItem entityItem) 
 	{
 		//Happens on servers for some reason.
-		if (entityItem.getEntityItem() != null)
+		if (entityItem.getEntityItem() != null && !entityItem.worldObj.isRemote)
 		{
 			updateBabyGrowth(entityItem.getEntityItem());
 		}

--- a/src/main/java/mca/packets/PacketMemorialUpdateGet.java
+++ b/src/main/java/mca/packets/PacketMemorialUpdateGet.java
@@ -62,7 +62,9 @@ public class PacketMemorialUpdateGet extends AbstractPacket implements IMessage,
 		try
 		{
 			final TileMemorial memorial = (TileMemorial)BlockHelper.getTileEntity(world, packet.x, packet.y, packet.z);
-			MCA.getPacketHandler().sendPacketToPlayer(new PacketMemorialUpdateSet(memorial), (EntityPlayerMP) player);
+			if (memorial != null) {
+			    MCA.getPacketHandler().sendPacketToPlayer(new PacketMemorialUpdateSet(memorial), (EntityPlayerMP) player);
+			}
 		}
 		
 		catch (ClassCastException e)


### PR DESCRIPTION
- Only run updateBabyGrowth logic on server side.
- Check if TE is null before attempting to construct a PacketMemorialUpdateGet.

Fixes #768 
Fixes #769 
Fixes #775 
