### PR TITLE
Fix villagers not regenerating to actual max health.

### DIFF
--- a/src/main/java/mca/ai/AIRegenerate.java
+++ b/src/main/java/mca/ai/AIRegenerate.java
@@ -31,7 +31,7 @@ public class AIRegenerate extends AbstractAI
 	{
 		if (timeUntilNextRegen <= 0)
 		{
-			int maxHealth = owner.getProfessionGroup() == EnumProfessionGroup.Guard ? MCA.getConfig().guardMaxHealth : MCA.getConfig().villagerMaxHealth;
+			float maxHealth = owner.getMaxHealth();
 			if (owner.getHealth() < maxHealth && owner.getHealth() > 0.0F)
 			{
 				owner.setHealth(owner.getHealth() + 1);


### PR DESCRIPTION
Useful if using a mod that adds modifiers to max health, one example being Scaling Health.
