### PR TITLE
Deprecated/1.10.2

### DIFF
--- a/src/main/java/mca/core/forge/EventHooksForge.java
+++ b/src/main/java/mca/core/forge/EventHooksForge.java
@@ -216,7 +216,7 @@ public class EventHooksForge
 			}
 		}
 
-		else if (event.getTarget() instanceof EntityPlayerMP && !event.getEntityPlayer().worldObj.isRemote && !event.getEntityPlayer().getName().contains("[CoFH]"))
+		else if (event.getTarget() instanceof EntityPlayerMP && !event.getEntityPlayer().worldObj.isRemote && !(event.getEntityPlayer() instanceof FakePlayer) && !event.getEntityPlayer().getName().contains("[CoFH]"))
 		{
 			MCA.getPacketHandler().sendPacketToPlayer(new PacketInteractWithPlayerC(event.getEntityPlayer(), (EntityPlayer)event.getTarget()), (EntityPlayerMP) event.getEntityPlayer());
 		}


### PR DESCRIPTION
Hey when you create a farm with the farming chore it crashes client and server side. I was wondering if you could do this in the farming AI class file? So servers can actually disable the chore unless you can fix it please and thank you. [
![after](https://user-images.githubusercontent.com/29715854/29197956-fad34f04-7e0d-11e7-8fa0-86847a6e0473.PNG)
](url)