### PR TITLE
Fix targeting system to include slimes

### DIFF
--- a/src/main/java/mca/actions/ActionCombat.java
+++ b/src/main/java/mca/actions/ActionCombat.java
@@ -6,7 +6,7 @@ import mca.core.Constants;
 import mca.entity.EntityVillagerMCA;
 import mca.enums.EnumCombatBehaviors;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.projectile.EntityTippedArrow;
 import net.minecraft.init.SoundEvents;
@@ -203,7 +203,7 @@ public class ActionCombat extends AbstractAction
 
 	public boolean isEntityValidToAttack(EntityLivingBase entity)
 	{
-		if (entity instanceof EntityMob &&
+		if (entity instanceof IMob &&
 				(getTargetBehavior() == EnumCombatBehaviors.TARGET_HOSTILE_MOBS || 
 				getTargetBehavior() == EnumCombatBehaviors.TARGET_PASSIVE_OR_HOSTILE_MOBS))
 		{


### PR DESCRIPTION
Slimes do not extend EntityMob and so are the MagmaCubes, yet they are mobs since they implement IMob. By changing it to IMob, you give the chance for other mods to implement targets that are not EntityMob and will still be attack-able. This change will include shulkers, ghasts, slimes(Mgama cubes too) and dragons.